### PR TITLE
Add syntax option for listtype, score and hide non-existing pages

### DIFF
--- a/_test/date.test.php
+++ b/_test/date.test.php
@@ -63,10 +63,58 @@ class best_top_test extends DokuWikiTest {
                     1 => array(
                         'lang' => '',
                         'month' => '',
+                        'tag' => 'ul',
+                        'score' => 'false',
                     )
                 ),
                 2 => DOKU_LEXER_SPECIAL,
                 3 => '{{top}}',
+            ),
+            2 => 1,
+        );
+        $this->assertEquals($expected_response, $parser_response);
+    }
+
+    function test_ol_syntax_parsing() {
+        $parser_response = p_get_instructions('{{top|tag=ol}}')[2];
+        $expected_response = array(
+            0 => 'plugin',
+            1 => array(
+                0 => 'top',
+                1 => array(
+                    0 => DOKU_LEXER_SPECIAL,
+                    1 => array(
+                        'lang' => '',
+                        'month' => '',
+                        'tag' => 'ol',
+                        'score' => 'false',
+                    )
+                ),
+                2 => DOKU_LEXER_SPECIAL,
+                3 => '{{top|tag=ol}}',
+            ),
+            2 => 1,
+        );
+        $this->assertEquals($expected_response, $parser_response);
+    }
+
+    function test_score_syntax_parsing() {
+        $parser_response = p_get_instructions('{{top|score=true}}')[2];
+        $expected_response = array(
+            0 => 'plugin',
+            1 => array(
+                0 => 'top',
+                1 => array(
+                    0 => DOKU_LEXER_SPECIAL,
+                    1 => array(
+                        'lang' => '',
+                        'month' => '',
+                        'tag' => 'ul',
+                        'score' => 'true',
+                    )
+                ),
+                2 => DOKU_LEXER_SPECIAL,
+                3 => '{{top|score=true}}',
             ),
             2 => 1,
         );
@@ -84,6 +132,8 @@ class best_top_test extends DokuWikiTest {
                     1 => array(
                         'lang' => '',
                         'month' => '201501',
+                        'tag' => 'ul',
+                        'score' => 'false',
                     )
                 ),
                 2 => DOKU_LEXER_SPECIAL,
@@ -105,6 +155,8 @@ class best_top_test extends DokuWikiTest {
                     1 => array(
                         'lang' => 'en',
                         'month' => '',
+                        'tag' => 'ul',
+                        'score' => 'false',
                     )
                 ),
                 2 => DOKU_LEXER_SPECIAL,
@@ -126,6 +178,8 @@ class best_top_test extends DokuWikiTest {
                     1 => array(
                         'lang' => 'en',
                         'month' => '201501',
+                        'tag' => 'ul',
+                        'score' => 'false',
                     )
                 ),
                 2 => DOKU_LEXER_SPECIAL,

--- a/syntax.php
+++ b/syntax.php
@@ -44,7 +44,7 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
      */
     public function handle($match, $state, $pos, Doku_Handler $handler) {
         if ($state==DOKU_LEXER_SPECIAL) {
-            $options = array('lang' => null, 'month' => null );
+            $options = array('lang' => null, 'month' => null, 'tag' => 'ul', 'score' => 'false' );
             $match = rtrim($match,'\}');
             $match = substr($match,5);
             if ($match != '') {
@@ -77,21 +77,32 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
         $hlp  = plugin_load('helper', 'top');
         $list = $hlp->best($data[1]['lang'],$data[1]['month'], 20);
 
-        $renderer->listo_open();
+        if($data[1]['tag'] == 'ol') {
+            $renderer->listo_open();
+        } else {
+            $renderer->listu_open();
+        }
+
         $num_items=0;
         foreach($list as $item) {
             if (auth_aclcheck($item['page'],'',null) < AUTH_READ) continue;
+            if (!page_exists($item['page'])) continue;
             $num_items = $num_items +1;
             $renderer->listitem_open(1);
             if (strpos($item['page'],':') === false) {
                 $item['page'] = ':' . $item['page'];
             }
             $renderer->internallink($item['page']);
-            $renderer->cdata(' (' . $item['value'] . ')');
+            if ($data[1]['score'] === 'true') $renderer->cdata(' (' . $item['value'] . ')');
             $renderer->listitem_close();
             if ($num_items >= 10) break;
         }
-        $renderer->listo_close();
+
+        if($data[1]['tag'] == 'ol') {
+            $renderer->listo_close();
+        } else {
+            $renderer->listu_close();
+        }
         return true;
     }
 }


### PR DESCRIPTION
- Per default the list-type is now again ul, to better hide missing pages,
- the score is not shown per default
- non-existing pages are hidden
- Add two tests for the liste-type and the score
