### PR TITLE
Add conf option to show non public pages

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -2,3 +2,4 @@
 
 
 $conf['hide_start_pages'] = 1;
+$conf['show_only_public'] = 1;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,3 +1,4 @@
 <?php
 
 $meta['hide_start_pages'] = array('onoff');
+$meta['show_only_public'] = array('onoff');

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -1,3 +1,4 @@
 <?php
 
 $lang['hide_start_pages'] = 'Zeige die Startseite(n) des Wikis nicht an.';
+$lang['show_only_public'] = 'Zeige nur öffentliche Seiten an';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,3 +1,4 @@
 <?php
 
 $lang['hide_start_pages'] = 'Hide the startpage of the wiki and its translation namespaces';
+$lang['show_only_public'] = 'Show only public pages';

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   top
 author Andreas Gohr
 email  gohr@cosmocode.de
-date   2015-04-16
+date   2015-11-16
 name   top plugin
 desc   show the top ten most visited pages
 url    https://www.dokuwiki.org/plugin:top

--- a/syntax.php
+++ b/syntax.php
@@ -85,7 +85,11 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
 
         $num_items=0;
         foreach($list as $item) {
-            if (auth_aclcheck($item['page'],'',null) < AUTH_READ) continue;
+            if ($this->getConf('show_only_public')) {
+                if (auth_aclcheck($item['page'],'',null) < AUTH_READ) continue;
+            } else {
+                if (auth_quickaclcheck($item['page']) < AUTH_READ) continue;
+            }
             if (!page_exists($item['page'])) continue;
             $num_items = $num_items +1;
             $renderer->listitem_open(1);


### PR DESCRIPTION
By default top only displays public pages. There is now an option in the configuration menu to display all pages where a user has at least read permission.

fixes #7 
