### PR TITLE
Updated Lookup Patten

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -30,7 +30,7 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
      * @param string $mode Parser mode
      */
     public function connectTo($mode) {
-        $this->Lexer->addSpecialPattern('\\{\\{top(?:.*?)\\}\\}', $mode, 'plugin_top');
+        $this->Lexer->addSpecialPattern('\\{\\{top(?:\|.+?|)\\}\\}', $mode, 'plugin_top');
     }
 
     /**

--- a/syntax.php
+++ b/syntax.php
@@ -30,7 +30,7 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
      * @param string $mode Parser mode
      */
     public function connectTo($mode) {
-        $this->Lexer->addSpecialPattern('\\{\\{top(?:\|.+?|)\\}\\}', $mode, 'plugin_top');
+        $this->Lexer->addSpecialPattern('\\{\\{top(?:\|.+?)?\\}\\}', $mode, 'plugin_top');
     }
 
     /**


### PR DESCRIPTION
Updated lookup pattern fixes #9. The previous lookup pattern captured any tag starting with "top", regardless of what comes after it, this interfered with the tag plugin, which uses the tag "topic". The new pattern is more restrictive, it only captures a tag exactly matching "top" or a tag matching "top|" with any characters after the vertical bar.