### PR TITLE
Add whitelist/blacklist by page ID

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -48,8 +48,8 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
                              'month'        => null,
                              'tag'          => 'ul',
                              'score'        => 'false',
-                             'blacklist' => null,
-                             'whitelist' => null);
+                             'blacklist'    => null,
+                             'whitelist'    => null);
             $match = rtrim($match,'\}');
             $match = substr($match,5);
             if ($match != '') {
@@ -145,6 +145,7 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
             $renderer->listitem_close();
             if ($num_items >= 10) break;
         }
+
         if($data[1]['tag'] == 'ol') {
             $renderer->listo_close();
         } else {

--- a/syntax.php
+++ b/syntax.php
@@ -44,7 +44,12 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
      */
     public function handle($match, $state, $pos, Doku_Handler $handler) {
         if ($state==DOKU_LEXER_SPECIAL) {
-            $options = array('lang' => null, 'month' => null, 'tag' => 'ul', 'score' => 'false' );
+            $options = array('lang'         => null,
+                             'month'        => null,
+                             'tag'          => 'ul',
+                             'score'        => 'false',
+                             'blacklist' => null,
+                             'whitelist' => null);
             $match = rtrim($match,'\}');
             $match = substr($match,5);
             if ($match != '') {
@@ -85,13 +90,51 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
 
         $num_items=0;
         foreach($list as $item) {
+
+            // Filter by ACL
             if ($this->getConf('show_only_public')) {
                 if (auth_aclcheck($item['page'],'',null) < AUTH_READ) continue;
             } else {
                 if (auth_quickaclcheck($item['page']) < AUTH_READ) continue;
             }
+
+            // Filter by page display availability
             if (!page_exists($item['page'])) continue;
             if (isHiddenPage($item['page'])) continue;
+
+            // Filter by page blacklist
+            $arg_blacklist = $data[1]['blacklist'];
+            $blacklist_ok = true;
+            if ($arg_blacklist !== null) {
+                foreach (explode(" ",$arg_blacklist) as $blacklist_term) {
+                    if (strpos($item['page'], $blacklist_term) !== false) {
+                        dbglog("plugin:top:blacklist: excluded '".$item['page'].
+                               "' because '".$blacklist_term."'");
+                        $blacklist_ok = false;
+                    }
+                }
+                if ($blacklist_ok !== true) {
+                    continue;
+                }
+            }
+
+            // Filter by page whitelist
+            $arg_whitelist = $data[1]['whitelist'];
+            $whitelist_ok = false;
+            if ($arg_whitelist !== null) {
+                foreach (explode(" ",$arg_whitelist) as $whitelist_term) {
+                    if (strpos($item['page'], $whitelist_term) !== false) {
+                        dbglog("plugin:top:whitelist: included '".$item['page'].
+                               "' because '".$whitelist_term."'");
+                        $whitelist_ok = true;
+                    }
+                }
+                if ( $whitelist_ok !== true ) { 
+                    continue;
+                }
+            }
+
+            // Display this page
             $num_items = $num_items +1;
             $renderer->listitem_open(1);
             if (strpos($item['page'],':') === false) {
@@ -102,7 +145,6 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
             $renderer->listitem_close();
             if ($num_items >= 10) break;
         }
-
         if($data[1]['tag'] == 'ol') {
             $renderer->listo_close();
         } else {


### PR DESCRIPTION
Space-separated blacklist and whitelist parameters offer simple needle-haystack inclusion and exclusion by page ID.

Blacklist applied first; whitelist applied to remainder, so any page matching on both whitelist and blacklist will be excluded.