### PR TITLE
Make top pages available via DokuWiki's feed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: php
 php:
+  - "nightly"
+  - "7.3"
+  - "7.2"
+  - "7.1"
   - "7.0"
   - "5.6"
-  - "5.5"
-  - "5.4"
-  - "5.3"
 env:
-  - DOKUWIKI=master
-  - DOKUWIKI=stable
+    matrix:
+        - DOKUWIKI=master
+        - DOKUWIKI=stable
+matrix:
+    allow_failures:
+        - php: "nightly"
 before_install: wget https://raw.github.com/splitbrain/dokuwiki-travis/master/travis.sh
 install: sh travis.sh
-script: cd _test && phpunit --stderr --group plugin_top
+script: cd _test && ./phpunit.phar --stderr --group plugin_top

--- a/_test/date.test.php
+++ b/_test/date.test.php
@@ -10,7 +10,7 @@
  */
 
 class best_top_test extends DokuWikiTest {
-    protected $pluginsEnabled = array('top','sqlite');
+    protected $pluginsEnabled = array('top','sqlite', 'translation');
 
     function test_best() {
 

--- a/action.php
+++ b/action.php
@@ -6,9 +6,6 @@
  * @author  Andreas Gohr <gohr@cosmocode.de>
  */
 
-// must be run within Dokuwiki
-if(!defined('DOKU_INC')) die();
-
 class action_plugin_top extends DokuWiki_Action_Plugin {
 
     /**
@@ -17,31 +14,31 @@ class action_plugin_top extends DokuWiki_Action_Plugin {
      * @param Doku_Event_Handler $controller DokuWiki's event controller object
      * @return void
      */
-    public function register(Doku_Event_Handler $controller) {
+    public function register(Doku_Event_Handler $controller)
+    {
         global $ACT;
         global $JSINFO;
         $JSINFO['act'] = $ACT;
-        $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handle_ajax_call_unknown');
-   
+
+        $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handleAjax');
     }
 
     /**
-     * [Custom event handler which performs action]
+     * Handle Ajax calls intended for this plugin
      *
      * @param Doku_Event $event  event object by reference
-     * @param mixed      $param  [the parameters passed as fifth argument to register_hook() when this
-     *                           handler was registered]
      * @return void
      */
 
-    public function handle_ajax_call_unknown(Doku_Event &$event, $param) {
-        if($event->data != 'plugin_top') return;
+    public function handleAjax(Doku_Event $event)
+    {
+        if ($event->data != 'plugin_top') return;
         $event->preventDefault();
         $event->stopPropagation();
 
         global $INPUT;
         $page = cleanID($INPUT->str('page'));
-        if(!$page) return;
+        if (!$page) return;
 
         /** @var helper_plugin_top $hlp */
         $hlp = plugin_load('helper', 'top');

--- a/action.php
+++ b/action.php
@@ -78,6 +78,7 @@ class action_plugin_top extends DokuWiki_Action_Plugin {
         if (empty($pages)) return;
 
         foreach ($pages as $page) {
+            if (!$hlp->isReadable($page['page'])) continue;
             $event->data['data'][] = [
                 'id' => $page['page'],
                 'score' => $page['value'],

--- a/action.php
+++ b/action.php
@@ -22,7 +22,6 @@ class action_plugin_top extends DokuWiki_Action_Plugin {
 
         $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handleAjax');
         $controller->register_hook('FEED_MODE_UNKNOWN', 'BEFORE', $this, 'handleFeed');
-        $controller->register_hook('FEED_ITEM_ADD', 'BEFORE', $this, 'handleFeedItemAdd');
     }
 
     /**
@@ -84,20 +83,6 @@ class action_plugin_top extends DokuWiki_Action_Plugin {
                 'score' => $page['value'],
             ];
         }
-    }
-
-    /**
-     * Set our data in feed item
-     *
-     * @param Doku_Event $event
-     */
-    public function handleFeedItemAdd(Doku_Event $event)
-    {
-        if ($event->data['opt']['feed_mode'] !== 'plugin-top') return;
-
-        $event->data['item']->title = $event->data['ditem']['id'];
-        $event->data['item']->link = hsc(wl($event->data['ditem']['id'], '', true));
-        $event->data['item']->description = $event->data['ditem']['score'];
     }
 }
 // vim:ts=4:sw=4:et:

--- a/helper.php
+++ b/helper.php
@@ -122,5 +122,24 @@ class helper_plugin_top extends DokuWiki_Plugin {
         $list = array_values($list);
         return $list;
     }
+
+    /**
+     * Returns true if the given page can be read by current user
+     *
+     * @param $id
+     * @return bool
+     */
+    public function isReadable($id)
+    {
+        if ($this->getConf('show_only_public')) {
+            if (auth_aclcheck($id, '', null) < AUTH_READ) return false;
+        } else {
+            if (auth_quickaclcheck($id) < AUTH_READ) return false;
+        }
+        if (!page_exists($id)) return false;
+        if (isHiddenPage($id)) return false;
+
+        return true;
+    }
 }
 // vim:ts=4:sw=4:et:

--- a/helper.php
+++ b/helper.php
@@ -6,37 +6,31 @@
  * @author  Andreas Gohr <gohr@cosmocode.de>
  */
 
-// must be run within Dokuwiki
-if(!defined('DOKU_INC')) die();
-
 class helper_plugin_top extends DokuWiki_Plugin {
 
     /** @var helper_plugin_sqlite */
     protected $sqlite = null;
 
-    /**
-     * initializes the DB connection
-     *
-     * @return helper_plugin_sqlite|null
-     */
-    public function getDBHelper() {
-        if(!is_null($this->sqlite)) return $this->sqlite;
-
+    public function __construct()
+    {
         $this->sqlite = plugin_load('helper', 'sqlite');
-        if(!$this->sqlite) {
+        if (!$this->sqlite) {
             msg('The top plugin requires the sqlite plugin', -1);
-            $this->sqlite = null;
-            return null;
         }
 
-        $ok = $this->sqlite->init('top', __DIR__ . '/db');
-        if(!$ok) {
-            msg('rating plugin sqlite initialization failed', -1);
-            $this->sqlite = null;
+        if (!$this->sqlite->init('top', __DIR__ . '/db')) {
+            msg('top plugin: sqlite initialization failed', -1);
             return null;
         }
+    }
 
-        return $this->sqlite;
+    /**
+     * Access to plugin's database
+     * @return helper_plugin_sqlite
+     */
+    public function getDBHelper()
+    {
+       return $this->sqlite;
     }
 
     /**
@@ -44,16 +38,14 @@ class helper_plugin_top extends DokuWiki_Plugin {
      *
      * @param string $page the page id
      */
-    public function add($page) {
-        $sqlite = $this->getDBHelper();
-        if(!$sqlite) return;
-
+    public function add($page)
+    {
         // ignore any bot accesses
-        if(!class_exists('Jaybizzle\CrawlerDetect\CrawlerDetect')){
+        if (!class_exists('Jaybizzle\CrawlerDetect\CrawlerDetect')){
             require (__DIR__ . '/CrawlerDetect.php');
         }
         $CrawlerDetect = new Jaybizzle\CrawlerDetect\CrawlerDetect();
-        if($CrawlerDetect->isCrawler()) return;
+        if ($CrawlerDetect->isCrawler()) return;
 
         $translation = plugin_load('helper', 'translation');
         if (!$translation) {
@@ -66,37 +58,37 @@ class helper_plugin_top extends DokuWiki_Plugin {
 
         $sql = "INSERT OR REPLACE INTO toppages (page, value, lang, month)
                   VALUES ( ?, COALESCE( (SELECT value FROM toppages WHERE page = ? and month = ? ) + 1, 1), ?, ?)";
-        $res = $sqlite->query($sql, $page, $page, $month, $lang, $month);
-        $sqlite->res_close($res);
+        $res = $this->sqlite->query($sql, $page, $page, $month, $lang, $month);
+        $this->sqlite->res_close($res);
     }
 
     /**
      * Get the most visited pages
      *
+     * @param $lang
+     * @param $month
      * @param int $num
      * @return array
      */
-    public function best($lang, $month, $num = 10) {
-        $sqlite = $this->getDBHelper();
-        if(!$sqlite) return array();
-
+    public function best($lang, $month, $num = 10)
+    {
         $sqlbegin  = "SELECT SUM(value) as value, page FROM toppages ";
         $sqlend = "GROUP BY page ORDER BY value DESC LIMIT ?";
         if ($lang === null && $month === null){
             $sql = $sqlbegin . $sqlend;
-            $res  = $sqlite->query($sql, $num);
+            $res  = $this->sqlite->query($sql, $num);
         } elseif ($lang !== null && $month === null) {
             $sql = $sqlbegin . "WHERE lang = ? " . $sqlend;
-            $res  = $sqlite->query($sql, $lang, $num);
+            $res  = $this->sqlite->query($sql, $lang, $num);
         } elseif ($lang === null && $month !== null){
             $sql = $sqlbegin . "WHERE month >= ? " . $sqlend;
-            $res  = $sqlite->query($sql, intval($month), $num);
+            $res  = $this->sqlite->query($sql, intval($month), $num);
         } else {
             $sql = $sqlbegin . "WHERE lang = ? AND month >= ? " . $sqlend;
-            $res  = $sqlite->query($sql, $lang, intval($month), $num);
+            $res  = $this->sqlite->query($sql, $lang, intval($month), $num);
         }
-        $list = $sqlite->res2arr($res);
-        $sqlite->res_close($res);
+        $list = $this->sqlite->res2arr($res);
+        $this->sqlite->res_close($res);
 
         if ($this->getConf('hide_start_pages')) {
             $list = $this->removeStartPages($list);
@@ -104,6 +96,10 @@ class helper_plugin_top extends DokuWiki_Plugin {
         return $list;
     }
 
+    /**
+     * @param array $list
+     * @return array
+     */
     public function removeStartPages($list) {
         global $conf;
         $start = $conf['start'];
@@ -125,7 +121,5 @@ class helper_plugin_top extends DokuWiki_Plugin {
         $list = array_values($list);
         return $list;
     }
-
 }
-
 // vim:ts=4:sw=4:et:

--- a/helper.php
+++ b/helper.php
@@ -16,6 +16,7 @@ class helper_plugin_top extends DokuWiki_Plugin {
         $this->sqlite = plugin_load('helper', 'sqlite');
         if (!$this->sqlite) {
             msg('The top plugin requires the sqlite plugin', -1);
+            return null;
         }
 
         if (!$this->sqlite->init('top', __DIR__ . '/db')) {

--- a/helper.php
+++ b/helper.php
@@ -65,8 +65,8 @@ class helper_plugin_top extends DokuWiki_Plugin {
     /**
      * Get the most visited pages
      *
-     * @param $lang
-     * @param $month
+     * @param string|null $lang
+     * @param string|null $month
      * @param int $num
      * @return array
      */

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 jQuery(function () {
-    if (JSINFO['act'] && JSINFO.act == 'show') {
+    if (JSINFO['act'] && JSINFO.act === 'show') {
         jQuery.post(
-                DOKU_BASE + 'lib/exe/ajax.php',
+            DOKU_BASE + 'lib/exe/ajax.php',
             {
                 call: 'plugin_top',
                 page: JSINFO.id

--- a/syntax.php
+++ b/syntax.php
@@ -6,21 +6,20 @@
  * @author  Andreas Gohr <gohr@cosmocode.de>
  */
 
-// must be run within Dokuwiki
-if(!defined('DOKU_INC')) die();
-
 class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
     /**
      * @return string Syntax mode type
      */
-    public function getType() {
+    public function getType()
+    {
         return 'protected';
     }
 
     /**
      * @return int Sort order - Low numbers go before high numbers
      */
-    public function getSort() {
+    public function getSort()
+    {
         return 200;
     }
 
@@ -29,7 +28,8 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
      *
      * @param string $mode Parser mode
      */
-    public function connectTo($mode) {
+    public function connectTo($mode)
+    {
         $this->Lexer->addSpecialPattern('\\{\\{top(?:\|.+?)?\\}\\}', $mode, 'plugin_top');
     }
 
@@ -42,7 +42,8 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
      * @param Doku_Handler $handler The handler
      * @return array Data for the renderer
      */
-    public function handle($match, $state, $pos, Doku_Handler $handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler)
+    {
         if ($state==DOKU_LEXER_SPECIAL) {
             $options = array('lang' => null, 'month' => null, 'tag' => 'ul', 'score' => 'false' );
             $match = rtrim($match,'\}');
@@ -50,7 +51,7 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
             if ($match != '') {
                 $match = ltrim($match,'\|');
                 $match = explode(",", $match);
-                foreach($match as $option) {
+                foreach ($match as $option) {
                     list($key, $val) = explode('=', $option);
                     $options[$key] = $val;
                 }
@@ -69,24 +70,25 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
      * @param array $data The data from the handler() function
      * @return bool If rendering was successful.
      */
-    public function render($mode, Doku_Renderer $renderer, $data) {
-        if($mode == 'metadata') return false;
-        if($data[0] != DOKU_LEXER_SPECIAL) return false;
+    public function render($mode, Doku_Renderer $renderer, $data)
+    {
+        if ($mode == 'metadata') return false;
+        if ($data[0] != DOKU_LEXER_SPECIAL) return false;
 
         /** @var helper_plugin_top $hlp */
         $hlp  = plugin_load('helper', 'top');
-        $list = $hlp->best($data[1]['lang'],$data[1]['month'], 20);
+        $list = $hlp->best($data[1]['lang'], $data[1]['month'], 20);
 
-        if($data[1]['tag'] == 'ol') {
+        if ($data[1]['tag'] == 'ol') {
             $renderer->listo_open();
         } else {
             $renderer->listu_open();
         }
 
         $num_items=0;
-        foreach($list as $item) {
+        foreach ($list as $item) {
             if ($this->getConf('show_only_public')) {
-                if (auth_aclcheck($item['page'],'',null) < AUTH_READ) continue;
+                if (auth_aclcheck($item['page'], '', null) < AUTH_READ) continue;
             } else {
                 if (auth_quickaclcheck($item['page']) < AUTH_READ) continue;
             }
@@ -94,7 +96,7 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
             if (isHiddenPage($item['page'])) continue;
             $num_items = $num_items +1;
             $renderer->listitem_open(1);
-            if (strpos($item['page'],':') === false) {
+            if (strpos($item['page'], ':') === false) {
                 $item['page'] = ':' . $item['page'];
             }
             $renderer->internallink($item['page']);
@@ -103,7 +105,7 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
             if ($num_items >= 10) break;
         }
 
-        if($data[1]['tag'] == 'ol') {
+        if ($data[1]['tag'] == 'ol') {
             $renderer->listo_close();
         } else {
             $renderer->listu_close();
@@ -111,5 +113,4 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
         return true;
     }
 }
-
 // vim:ts=4:sw=4:et:

--- a/syntax.php
+++ b/syntax.php
@@ -87,13 +87,7 @@ class syntax_plugin_top extends DokuWiki_Syntax_Plugin {
 
         $num_items=0;
         foreach ($list as $item) {
-            if ($this->getConf('show_only_public')) {
-                if (auth_aclcheck($item['page'], '', null) < AUTH_READ) continue;
-            } else {
-                if (auth_quickaclcheck($item['page']) < AUTH_READ) continue;
-            }
-            if (!page_exists($item['page'])) continue;
-            if (isHiddenPage($item['page'])) continue;
+            if (!$hlp->isReadable($item['page'])) continue;
             $num_items = $num_items +1;
             $renderer->listitem_open(1);
             if (strpos($item['page'], ':') === false) {


### PR DESCRIPTION
This PR makes top pages available through the RSS endpoint (`feed.php`).

The required parameter is `mode=plugin-top`. All options available in syntax are also supported.

Feed items contain very little data:

```xml
<item rdf:about="http://doku.wiki/doku.php?id=test:plugins:top">
    <dc:format>text/html</dc:format>
    <dc:date>2020-11-24T12:56:00+00:00</dc:date>
    <dc:creator>Anonymous (anonymous@undisclosed.example.com)</dc:creator>
    <title>test:plugins:top</title>
    <link>http://doku.wiki/doku.php?id=test:plugins:top</link>
    <description>3</description>
</item>
```